### PR TITLE
Fix aws profile override bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='aws-session-credentials',
-    version='0.1.0',
+    version='0.1.1',
     description='Manage AWS session credentials',
     url='https://github.com/thumbtack/aws-session-credentials',
     author='Thumbtack SRE',


### PR DESCRIPTION
Previously, when a session expired while using the `-nc` flags, any
future runs of the script would be unable to find a set of credentials
using the credentials file, since the `AWS_PROFILE` envvar was set to
the set of session credentials. This change caches the original
`AWS_PROFILE` value and specifically avoids using the session
credentials section of the credentials file.