### PR TITLE
Explicitly use default profile by default

### DIFF
--- a/aws_session_credentials/aws_session_credentials.py
+++ b/aws_session_credentials/aws_session_credentials.py
@@ -156,7 +156,7 @@ def load_permanent_credentials(aws_profile):
     '''Load permanent user credentials if they can be found'''
     resolver = botocore.credentials.create_credential_resolver(
         botocore.session.Session(
-            profile=(aws_profile or None)
+            profile=(aws_profile or 'default')
         )
     )
     # find the first provider that doesn't provide session credentials

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
 
+import os
+
 import setuptools
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+README = os.path.join(HERE, 'README.rst')
+with open(README, 'r') as handle:
+    LONG_DESCRIPTION = handle.read()
 
 setuptools.setup(
     name='aws-session-credentials',
-    version='0.1.1',
+    version='0.1.2',
     description='Manage AWS session credentials',
+    long_description=LONG_DESCRIPTION,
     url='https://github.com/thumbtack/aws-session-credentials',
     author='Thumbtack SRE',
     license='Apache License 2.0',


### PR DESCRIPTION
Some systems will use the aws_session_credentials profile if no
default profile is specified, so explicitly specify the 'default'
profile as the default.